### PR TITLE
Allow user to specify external source for an img shortcode.

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,5 +1,5 @@
 <figure{{ if .Get "class" }} class="{{ .Get "class" }}"{{ end }}>
-  <amp-img src="{{ $.Site.BaseURL }}{{ .Get "src" }}" alt="{{ .Page.Title }} {{ .Get "src" }}" width={{ .Get "w" | default "640" }} height={{ .Get "h" | default "400"}} layout="responsive"></amp-img>
+  <amp-img src="{{ if .Get "localsrc" }}{{ $.Site.BaseURL }}{{ .Get "localsrc" }}{{ else }}{{ .Get "src" }}{{ end }}" alt="{{ .Page.Title }} {{ .Get "src" }}" width={{ .Get "w" | default "640" }} height={{ .Get "h" | default "400"}} layout="responsive"></amp-img>
   {{ if .Get "caption" }}
   <figcaption>
     {{ if .Get "href" }}


### PR DESCRIPTION
Use localsrc for a local files instead, and src for external as usual